### PR TITLE
Halo: Fix typo: \specs should be \spec

### DIFF
--- a/classes/Halo.sc
+++ b/classes/Halo.sc
@@ -73,7 +73,7 @@ Halo : Library {
 
 	getSpec { |name|
 		var spec;
-		var specs = Halo.at(this, \specs);
+		var specs = Halo.at(this, \spec);
 		if (name.isNil) { ^specs };
 		if (specs.notNil) { spec = specs.at(name) };
 		^spec ?? { name.asSpec }


### PR DESCRIPTION
Without the fix:

```
Ndef(\a, { |freq = 440| SinOsc.ar(freq, 0, 0.1) });
Ndef(\a).addSpec(\freq, #[100, 800, \exp]);
Ndef(\a).getSpec(\freq)
-> a ControlSpec(20, 20000, 'exp', 0, 440, " Hz")
```

The lookup fails because addSpec puts into Halo under `\spec`, but getSpec looks under `\specs`.