### PR TITLE
Halo: Send .changed notification after an item is set

### DIFF
--- a/classes/Halo.sc
+++ b/classes/Halo.sc
@@ -73,7 +73,7 @@ Halo : Library {
 
 	getSpec { |name|
 		var spec;
-		var specs = Halo.at(this, \specs);
+		var specs = Halo.at(this, \spec);
 		if (name.isNil) { ^specs };
 		if (specs.notNil) { spec = specs.at(name) };
 		^spec ?? { name.asSpec }

--- a/classes/Halo.sc
+++ b/classes/Halo.sc
@@ -11,6 +11,7 @@ Halo : Library {
 
 	*put { |...args|
 		lib.put(*args);
+		args[0].changed(*args[1..]);
 	}
 
 	*at { | ... keys| ^lib.at(*keys); }


### PR DESCRIPTION
Use case: Make it easier to manage a GUI that depends on a NodeProxy control's spec. Without this, you have to scan all the specs periodically to see if something changed.

This is actually just one commit, if you merge #1 first.