### PR TITLE
Halo: Send .changed notification when an item is set

### DIFF
--- a/classes/Halo.sc
+++ b/classes/Halo.sc
@@ -11,6 +11,7 @@ Halo : Library {
 
 	*put { |...args|
 		lib.put(*args);
+		args[0].changed(*args[1..]);
 	}
 
 	*at { | ... keys| ^lib.at(*keys); }


### PR DESCRIPTION
Use case: Make it easier to manage a GUI that depends on a NodeProxy control's spec. Without this, you have to scan all the specs periodically to see if something changed.