### PR TITLE
Halo: Use proxy key for spec for '#' parameters

### DIFF
--- a/classes/Halo.sc
+++ b/classes/Halo.sc
@@ -78,6 +78,10 @@ Halo : Library {
 		var specs = Halo.at(this, \spec);
 		if (name.isNil) { ^specs };
 		if (specs.notNil) { spec = specs.at(name) };
+		if (spec.isNil and: { name == '#' }) {
+			name = this.key;
+			if (specs.notNil) { spec = specs.at(name) };
+		};
 		^spec ?? { name.asSpec }
 	}
 


### PR DESCRIPTION
```
p = ProxySpace.new.push;

~freq = 110;
~freq.getSpec('#');

-> nil

~freq.addSpec('#', \freq);
```

It seems redundant and inconvenient to require the last statement. This PR adds logic to look up a spec for `\freq` if the control name given is `'#'` and the proxy is stored under `\freq`.
