### PR TITLE
ProxyPreset: randSet skip keys with no spec

### DIFF
--- a/classes/Presets/ProxyPreset.sc
+++ b/classes/Presets/ProxyPreset.sc
@@ -296,11 +296,12 @@ ProxyPreset {
 					[key, spec.map(randVal)];
 				} {
 					"no spec: %\n".postf([key, val]);
+					nil;
 				};
 			};
 		}.valueSeed(seed);
 
-		^randKeysVals;
+		^randKeysVals.reject(_.isNil);
 	}
 
 


### PR DESCRIPTION
ProxyPreset.randSet currently sets garbage data in proxy's keysValues: in case there's no spec for a key, the whole warning message string is returned as part of the array of new pairs to be set.
This PR returns nil instead, and filters out nils before returning new pairs.

Fixes issue #16 
Issue reproducer:
```supercollider
Ndef(\test1){|freqs=440| SinOsc.ar(freqs)}
NdefPreset(Ndef(\test1))
Ndef(\test1).gui
NdefPreset(\test1).setRand

Ndef(\test1).getKeysValues 
// -> [ [ freqs, 440 ], [ c, : ], [  , f ], [ 0,   ], [ 4, 4 ], [ p, e ], [ ,,   ], [ r, e ], [ ], 
 ], [ q, s ], [ n, o ] ]
```