### PR TITLE
Fixes example in ProxyMeter documentation

### DIFF
--- a/HelpSource/Classes/ProxyMeter.schelp
+++ b/HelpSource/Classes/ProxyMeter.schelp
@@ -174,7 +174,7 @@ ProxyMeter.addNdefGui(n);
 ProxyMeter.removeNdefGui(n);
 
 g = MonitorGui(Ndef(\a));
-ProxyMeter.addMonitorGui(n);
-ProxyMeter.removeMonitorGui(n);
+ProxyMeter.addMonitorGui(g);
+ProxyMeter.removeMonitorGui(g);
 
 ::


### PR DESCRIPTION
The last example in the ProxyMeter documentation is using the wrong variable for MonitorGui