### PR TITLE
Halo: checkSpec's dependant should not releaseDependants

### DIFF
--- a/classes/Halo.sc
+++ b/classes/Halo.sc
@@ -42,6 +42,13 @@ Halo : Library {
 
 	checkSpec {
 		var specs = Halo.at(this, \spec);
+		var func = { |who, what|
+			if (what == \clear) {
+				this.removeDependant(func);
+				this.clearHalo;  // will drop the func reference too
+			};
+		};
+
 		if (specs.notNil) { ^specs };
 
 		specs = ();
@@ -52,12 +59,10 @@ Halo : Library {
 		};
 
 		Halo.put(this, \spec, specs);
-		this.addDependant({ |who, what|
-			if (what == \clear) {
-				this.removeDependant(thisFunction);
-				this.clearHalo;
-			};
-		});
+		if(Halo.at(this, \clearWatcher).isNil) {
+			Halo.put(this, \clearWatcher, func);
+			this.addDependant(func);
+		};
 		^specs
 	}
 

--- a/classes/Halo.sc
+++ b/classes/Halo.sc
@@ -54,7 +54,7 @@ Halo : Library {
 		Halo.put(this, \spec, specs);
 		this.addDependant({ |who, what|
 			if (what == \clear) {
-				this.releaseDependants;
+				this.removeDependant(thisFunction);
 				this.clearHalo;
 			};
 		});


### PR DESCRIPTION
Fixes #27.

`releaseDependants` is inappropriate here because you have no guarantee that Halo is the only interface creating dependencies. The only dependant that Halo is authorized to remove is the one that it created.