### PR TITLE
add currentSettingsAsCompileString

### DIFF
--- a/classes/extNodeProxyDocument.sc
+++ b/classes/extNodeProxyDocument.sc
@@ -1,0 +1,15 @@
++ NodeProxy {
+	currentSettingsAsCompileString { | envir |
+		var nameStr, accessStr = "a";
+		var isAnon;
+
+		envir = envir ? currentEnvironment;
+
+		nameStr = envir.use { this.asCompileString };
+		isAnon = nameStr.beginsWith("a = ");
+		if (isAnon.not) { accessStr = nameStr };
+
+		^this.nodeMap.asCode(accessStr, true);
+
+	}
+}


### PR DESCRIPTION
I often find myself in the situation that I'd like to save only the specific settings for a NodeProxy.
This method (extracted from `NodeProxy:asCode`, [src](https://github.com/supercollider/supercollider/blob/09f04c8d44f94960b00829b6cdef31a504254e5f/SCClassLibrary/JITLib/ProxySpace/extStoreOn.sc#L159)) returns the current settings as a `compileString`, ready to be used further.

I am unsure about the (quite clunky) name, feedback welcome.

Here is a testcase:


```sc
(
Ndef(\testMeSettings, {|amp = 0.1, fFreq = 100, fRq = 0.1|
	RLPF.ar(WhiteNoise.ar(amp, AmpComp.kr(fFreq)), fFreq, fRq)!2
})
)

Ndef(\testMeSettings).play
Ndef(\testMeSettings).set(\fFreq, exprand(100, 4000), \fRq, rrand(0.01, 2))


Ndef(\testMeSettings).currentSettingsAsCompileString;
// -> Ndef('testMeSettings').set('fFreq', 551.13632443201, 'fRq', 0.46147141933441);
```