### PR TITLE
Allow NdefPreset to work with Ndefs running other server than Server.default

### DIFF
--- a/classes/Presets/NdefPreset.sc
+++ b/classes/Presets/NdefPreset.sc
@@ -47,14 +47,14 @@ NdefPreset : NodeProxyPreset {
 		if (key.isKindOf(this.proxyClass)) {
 			proxy = key;
 			key = proxy.key;
+		} {
+			// find proxy with same name in the default Server
+			proxy = this.proxyClass.dictFor(Server.default)[key];
 		};
 
 		res = all[key];
 
 		if (res.isNil) {
-			// find proxy with same name
-			proxy = this.proxyClass.dictFor(Server.default)[key];
-
 			if (proxy.notNil) {
 				res = super.new(proxy, namesToStore,
 					settings, specs, morphFuncs).prAdd(key);


### PR DESCRIPTION
I've been working with Ndefs running on different (local) servers and I realized that currently you can't easily use NdefPreset with Ndefs running on different servers (by using association as key), since it forces to get the Proxy by the key from the Server.default dict.

This PR proposes a very small change to fix that.

To test:

```
z = Server.new(\test, NetAddr("127.0.0.1", 57140));
z.waitForBoot {
	Ndef(\zz -> \test, {WhiteNoise.ar(\amp.kr)});
	NdefPresetGui(NdefPreset(Ndef(\zz -> \test)), 2);
}
```