### PR TITLE
Improve nodeproxy getSpec for implicit specs

### DIFF
--- a/HelpSource/getSpec.schelp
+++ b/HelpSource/getSpec.schelp
@@ -86,10 +86,13 @@ NdefPreset(Ndef(\tst)).addSet(\set_1); // add a setting
 NdefPreset(Ndef(\tst)).setRand(1.0).addSet(\set_2); // and s second
 NdefPreset(Ndef(\tst)).morph(0.5, \set_1, \set_2); // morph
 
-// using a global spec implicitly:
+// test using a global spec implicitly:
 Ndef(\x, { Pulse.ar(\lofreq.kr(200)) * 0.1 });
 Ndef(\x).getSpec(\lofreq); // look by name
 // use getSpec to get all specs, then look
 Ndef(\x).getSpec.lofreq; //-> found in Spec.specs
 
+// if you use patches with implicit specs that you will not change,
+// you can speed up access to them by adding them to the halo specs:
+Ndef(\x).addImplicitSpecsToHalo;
 ::

--- a/HelpSource/getSpec.schelp
+++ b/HelpSource/getSpec.schelp
@@ -10,8 +10,8 @@ JITLib proxies like PatternProxy (and thus TaskProxy, Pdef, and Tdef)
 and NodeProxy/Ndef and other objects have numerical settings, for which
 defining a Spec is useful: a practical mininum, maximum and curve (warp).
 
-getSpec and addSpec provide a general interface for proxies and
-all other objects that use .set methods for named parameters.
+In the JITLibExtensions quark, addSpec and getSpec provide a general interface
+for proxies and all other objects that use .set methods for named parameters.
 This makes it easy to set and access ranges for parameters,
 e.g. for GUIs and other interfaces:
 
@@ -39,7 +39,7 @@ code::
 // by implicit spec in the synth function(s), as in
 Ndef(\x, { Pulse.ar(\freqx.kr(200, spec: [3, 300, \exp])) })
 
-// and in the general JITLib way by addSpec (Halo).
+// and using JITLibExtensions, explicitly by addSpec.
 Ndef(\x).addSpec(\freqx, [3, 300, \exp])
 ::
 

--- a/HelpSource/getSpec.schelp
+++ b/HelpSource/getSpec.schelp
@@ -1,0 +1,83 @@
+title:: getSpec
+
+summary:: Using NodeProxy getSpec, specs and addSpec
+categories:: Guides
+related:: Classes/NodeProxy, Classes/PatternProxy, Classes/Halo
+
+subsection:: Using NodeProxy getSpec, specs and addSpec
+
+PatternProxy (and thus TaskProxy, Pdef, and Tdef, and all other objects
+	that use .set methods for named parameters) have a single way
+of setting and accessing ranges for parameters, e.g. for GUIs:
+
+code::
+Tdef(\x).set(\myfreq, 345);
+Tdef(\x).addSpec(\myfreq, [30, 3000, \exp]);
+Tdef(\x).gui; // uses myfreq spec
+// specs are accessed with:
+Tdef(\x).getSpec(\myfreq);
+// or this gets a dict with all specs
+Tdef(\x).getSpec;
+// when you change the spec later to tune it,
+// the gui immediately uses it.
+Tdef(\x).addSpec(\myfreq, [50, 5000, \exp]);
+// specs are also used for setting params with unipolar values:
+Tdef(\x).setUni(\myfreq, 0.5); // center of range is 500
+::
+
+For historical reasons, NodeProxy (and Ndef) has two ways to define a spec for a given parameter name:
+
+code::
+// by implicit spec in the synth function(s), as in
+Ndef(\x, { Pulse.ar(\freqx.kr(200, spec: [3, 300, \exp])) })
+
+// and in the general JITLib way by addSpec (Halo).
+Ndef(\x).addSpec(\freqx, [3, 300, \exp])
+::
+
+As the specs for the same param name can be different in these two places, it is necessary to decide which one to use. In JITLibExtensions, code::addSpec / Halo:: gets priority over implicit specs; so if nothing is found in the code::Halo::, then we look in code::proxy.specs::.
+
+This precedence is useful for tuning specs while the sound continues:
+once a good spec is found, one can place it back in the synth func.
+If you always prefer to use implicit specs, just use implicit specs only,
+or at least avoid also using addSpec for the same parameter name.
+
+subsection:: Tests and Examples for using addSpec and implicit specs
+code::
+Ndef(\x).clear;
+Ndef(\x).getSpec; // empty Event
+Ndef(\x).getSpec(\freqx); // nil
+
+// define an implicit spec in synthfunc:
+Ndef(\x, { Pulse.ar(\freqx.kr(200, spec: [3, 300, \exp])) * 0.1 });
+// it should be here:
+Ndef(\x).specs;
+// findFirstSpecFor should find it too
+Ndef(\x).findFirstSpecFor(\freqx);
+// and getSpec finds it
+Ndef(\x).getSpec(\freqx);
+
+Ndef(\x).addSpec(\ampx, \amp);
+
+Ndef(\x).getSpec; // gets both synth specs and halo specs
+
+// use addSpec to set ranges: the newly added explicit spec is used
+Ndef(\x).addSpec(\freqx, [5, 500, \exp]);
+Ndef(\x).getSpec(\freqx);
+Ndef(\x).getSpec
+
+// when we remove the explicit spec again ..
+Ndef(\x).addSpec(\freqx, nil);
+// we see the implicit one again.
+Ndef(\x).getSpec(\freqx);
+
+// test that getSpec also works in NdefPreset:
+Ndef(\tst, { SinOsc.ar(\freqsin.kr(400, spec:\freq)) }).gui;
+
+NdefPreset(Ndef(\tst)).addSet(\set_1); // add a setting
+NdefPreset(Ndef(\tst)).setRand(1.0).addSet(\set_2); // and s second
+NdefPreset(Ndef(\tst)).morph(0.5, \set_1, \set_2); // morph
+::
+
+
+

--- a/HelpSource/getSpec.schelp
+++ b/HelpSource/getSpec.schelp
@@ -1,28 +1,36 @@
 title:: getSpec
 
-summary:: Using NodeProxy getSpec, specs and addSpec
+summary:: Using Specs for proxy parameters: getSpec, addSpec, and specs
 categories:: Guides
-related:: Classes/NodeProxy, Classes/PatternProxy, Classes/Halo
+related:: Classes/NodeProxy, Classes/PatternProxy, Classes/Halo, Classes/Object
 
-subsection:: Using NodeProxy getSpec, specs and addSpec
+section:: Using Specs for proxy parameters: getSpec, addSpec, and specs
 
-PatternProxy (and thus TaskProxy, Pdef, and Tdef, and all other objects
-	that use .set methods for named parameters) have a single way
-of setting and accessing ranges for parameters, e.g. for GUIs:
+JITLib proxies like PatternProxy (and thus TaskProxy, Pdef, and Tdef)
+and NodeProxy/Ndef and other objects have numerical settings, for which
+defining a Spec is useful: a practical mininum, maximum and curve (warp).
+
+getSpec and addSpec provide a general interface for proxies and
+all other objects that use .set methods for named parameters.
+This makes it easy to set and access ranges for parameters,
+e.g. for GUIs and other interfaces:
 
 code::
 Tdef(\x).set(\myfreq, 345);
 Tdef(\x).addSpec(\myfreq, [30, 3000, \exp]);
-Tdef(\x).gui; // uses myfreq spec
+Tdef(\x).gui; // gui uses myfreq spec automatically
 // specs are accessed with:
 Tdef(\x).getSpec(\myfreq);
-// or this gets a dict with all specs
+// or this gets a dict with all known specs
 Tdef(\x).getSpec;
-// when you change the spec later to tune it,
+// when you change a spec later to tune it,
 // the gui immediately uses it.
 Tdef(\x).addSpec(\myfreq, [50, 5000, \exp]);
 // specs are also used for setting params with unipolar values:
 Tdef(\x).setUni(\myfreq, 0.5); // center of range is 500
+Tdef(\x).getUni(\myfreq);
+// this guarantees that values stay within the range,
+// and is easy to use with controllers, e.g. hardware sliders.
 ::
 
 For historical reasons, NodeProxy (and Ndef) has two ways to define a spec for a given parameter name:
@@ -35,7 +43,7 @@ Ndef(\x, { Pulse.ar(\freqx.kr(200, spec: [3, 300, \exp])) })
 Ndef(\x).addSpec(\freqx, [3, 300, \exp])
 ::
 
-As the specs for the same param name can be different in these two places, it is necessary to decide which one to use. In JITLibExtensions, code::addSpec / Halo:: gets priority over implicit specs; so if nothing is found in the code::Halo::, then we look in code::proxy.specs::.
+As the specs for the same parameter name can be different in these two places, it is necessary to decide which one will be used. In JITLibExtensions, code::addSpec / Halo:: gets priority over implicit specs; so if nothing is found in the code::Halo::, then we look in code::proxy.specs::.
 
 This precedence is useful for tuning specs while the sound continues:
 once a good spec is found, one can place it back in the synth func.
@@ -78,6 +86,3 @@ NdefPreset(Ndef(\tst)).addSet(\set_1); // add a setting
 NdefPreset(Ndef(\tst)).setRand(1.0).addSet(\set_2); // and s second
 NdefPreset(Ndef(\tst)).morph(0.5, \set_1, \set_2); // morph
 ::
-
-
-

--- a/HelpSource/getSpec.schelp
+++ b/HelpSource/getSpec.schelp
@@ -80,9 +80,16 @@ Ndef(\x).addSpec(\freqx, nil);
 Ndef(\x).getSpec(\freqx);
 
 // test that getSpec also works in NdefPreset:
-Ndef(\tst, { SinOsc.ar(\freqsin.kr(400, spec:\freq)) }).gui;
+Ndef(\tst, { SinOsc.ar(\freqsin.kr(400, spec: \freq)) }).gui;
 
 NdefPreset(Ndef(\tst)).addSet(\set_1); // add a setting
 NdefPreset(Ndef(\tst)).setRand(1.0).addSet(\set_2); // and s second
 NdefPreset(Ndef(\tst)).morph(0.5, \set_1, \set_2); // morph
+
+// using a global spec implicitly:
+Ndef(\x, { Pulse.ar(\lofreq.kr(200)) * 0.1 });
+Ndef(\x).getSpec(\lofreq); // look by name
+// use getSpec to get all specs, then look
+Ndef(\x).getSpec.lofreq; //-> found in Spec.specs
+
 ::

--- a/classes/GUI/SystemOverwrites/extMakeEnvirGui.sc
+++ b/classes/GUI/SystemOverwrites/extMakeEnvirGui.sc
@@ -10,64 +10,6 @@ Ndef('x')[5] = \mix -> { Dust2.ar };
 \wet2234d.isFilterRole  // false
 */
 
-+ Symbol {
-	// support for nodeproxy filter roles
-	isFilterRole {
-		var str, splitIndex, head, tail;
-		str = this.asString;
-		splitIndex = str.detectIndex(_.isDecDigit);
-		if (splitIndex.isNil) { ^false };
-
-		head = str.keep(splitIndex);
-		// roles could be looked up somewhere
-		if ([ "wet", "mix" ].any (_ == head).not) { ^false };
-
-		tail = str.drop(splitIndex);
-		^tail.every(_.isDecDigit);
-	}
-}
-
-+ Spec {
-
-	*guess { |key, value|
-
-		if (key.isFilterRole) { ^[0, 1].asSpec };
-
-		if (value.isKindOf(Array)) { value = value[0] };
-		if (value.isKindOf(SimpleNumber).not) { ^nil };
-
-		// label units as \guess so one can throw spec away later.
-		^if (value.abs > 0) {
-			ControlSpec(value/20, value*20, \exp, 0, value, \guess)
-		} {
-			ControlSpec(-2, 2, \lin, 0, value, \guess)
-		};
-	}
-}
-
-+ TaskProxy {
-	// use \orderNames in halo for maintaining non-alphabetic order of names
-	controlKeys {
-		var cKeys = this.getHalo(\orderedNames);
-		if (cKeys.notNil) { ^cKeys };
-		cKeys = if (envir.notNil) { envir.keys(Array).sort } { [] };
-		^cKeys;
-	}
-}
-
-+ NodeProxy {
-	getSpec { |key, value|
-		var foundspec;
-
-		if (this.respondsTo(\findFirstSpecFor)) {
-			foundspec = this.findFirstSpecFor(key);
-			if (foundspec.notNil) { ^foundspec }
-		};
-
-		^super.getSpec(key, value)
-	}
-}
-
 + TaskProxyGui {
 
 	object_ { |obj|

--- a/classes/ProxyChain/ProxyChain.sc
+++ b/classes/ProxyChain/ProxyChain.sc
@@ -39,6 +39,8 @@ ProxyChain {
 	classvar <all, <>blendSpec;
 
 	var <slotNames, <slotsInUse, <proxy, <sources;
+	var	<paramKeys, <wetIndices, <wetKeys, <slotNameDict;
+	var <paramsPerSlot;
 
 	*initClass {
 		allSources = ();
@@ -181,6 +183,7 @@ ProxyChain {
 		proxy = argProxy;
 		if (proxy.key.notNil) { all.put(proxy.key, this) };
 
+		slotNameDict = ();
 		this.slotNames_(argSlotNames);
 
 		proxy.addSpec;
@@ -206,8 +209,11 @@ ProxyChain {
 
 	remove { |key|
 	 	var oldSlotIndex = slotsInUse.indexOf(key);
-		if (oldSlotIndex.notNil) { proxy[oldSlotIndex] = nil; };
-		slotsInUse.remove(key);
+		if (oldSlotIndex.notNil) {
+			proxy[oldSlotIndex] = nil;
+			slotsInUse.remove(key);
+			this.updateSlotInfo;
+		};
 	}
 
 	addSlot { |key, index, wet|
@@ -236,6 +242,7 @@ ProxyChain {
 			srcDict.specs.keysValuesDo { |param, spec| proxy.addSpec(param, spec) };
 		};
 		proxy[index] = func;
+		this.updateSlotInfo;
 	}
 
 	setSlots { |keys, levels=#[], update=false|
@@ -320,4 +327,19 @@ ProxyChain {
 			slotName -> this.keysValuesAt(slotName);
 		}
 	}
+
+	updateSlotInfo {
+		paramKeys = proxy.controlKeys;
+		wetIndices = paramKeys.selectIndices(_.isFilterRole);
+		wetKeys = paramKeys[wetIndices];
+		paramsPerSlot = paramKeys.separate { |a, b| b.isFilterRole };
+		this.activeSlotNames.do { |name, i|
+			slotNameDict.put(name, wetKeys[i])
+		}
+	}
+
+	wetKeyForSlotName { |slotName| ^slotNameDict[slotName] }
+
+	slotNameForWetKey { |wetKey| ^slotNameDict.findKeyForValue(wetKey) }
+
 }

--- a/classes/ProxyChain/ProxyChain.sc
+++ b/classes/ProxyChain/ProxyChain.sc
@@ -39,7 +39,7 @@ ProxyChain {
 	classvar <all, <>blendSpec;
 
 	var <slotNames, <slotsInUse, <proxy, <sources;
-	var	<paramKeys, <wetIndices, <wetKeys, <slotNameDict;
+	var <paramKeys, <wetIndices, <wetKeys, <slotNameDict;
 	var <paramsPerSlot;
 
 	*initClass {

--- a/classes/SystemOverwrites/extNodeProxy.sc
+++ b/classes/SystemOverwrites/extNodeProxy.sc
@@ -1,0 +1,17 @@
+/* overwrite getSpec
+
+*/
+
++ NodeProxy {
+	getSpec { |key, value|
+		var foundspec;
+
+		if (this.respondsTo(\findFirstSpecFor)) {
+			foundspec = this.findFirstSpecFor(key);
+			if (foundspec.notNil) { ^foundspec }
+		};
+
+		^super.getSpec(key, value)
+	}
+}
+

--- a/classes/SystemOverwrites/extNodeProxy.sc
+++ b/classes/SystemOverwrites/extNodeProxy.sc
@@ -1,17 +1,49 @@
-/* overwrite getSpec
+/* overwrite getSpec:
+addSpec / Halo has priority over implicit specs;
+if nothing is found in Halo, look in proxy.specs.
 
+This precedence is useful for tuning specs while sound is running:
+once a good spec is found, one can place it in the synth func.
+If you always prefer to use implicit specs,
+just avoid using addSpec with the same parameter name.
+
+////// Test/Show using addSpec and implicit controls:
+
+// define an implicit spec in synthfunc:
+Ndef(\x, { Pulse.ar(\freqx.kr(200, spec: [3, 300, \exp])) * 0.1 });
+// it should be here:
+Ndef(\x).specs;
+// findFirstSpecFor should find it too
+Ndef(\x).findFirstSpecFor(\freqx);
+// and getSpec finds it
+Ndef(\x).getSpec(\freqx);
+
+// make sure we don't have one in the halo:
+Ndef(\x).addSpec(\freqx, nil);
+
+// use addSpec: the newly added explicit spec is used
+Ndef(\x).addSpec(\freqx, [5, 500, \exp]);
+Ndef(\x).getSpec(\freqx);
+
+// when we remove the explicit spec again ..
+Ndef(\x).addSpec(\freqx, nil);
+// we see the implicit one again.
+Ndef(\x).getSpec(\freqx);
 */
 
 + NodeProxy {
 	getSpec { |key, value|
-		var foundspec;
 
+		// always look in halo first:
+		var foundSpec = super.getSpec(key, value);
+		if (foundSpec.notNil) { ^foundSpec };
+
+		// if nothing in Halo, check in synthfunc metadata:
+		// requires recent SC3 version
 		if (this.respondsTo(\findFirstSpecFor)) {
-			foundspec = this.findFirstSpecFor(key);
-			if (foundspec.notNil) { ^foundspec }
+			foundSpec = this.findFirstSpecFor(key);
 		};
-
-		^super.getSpec(key, value)
+		// found or nil
+		^foundSpec
 	}
 }
-

--- a/classes/SystemOverwrites/extNodeProxy.sc
+++ b/classes/SystemOverwrites/extNodeProxy.sc
@@ -36,7 +36,7 @@ or at least avoid also using addSpec for the same parameter name.
 			if (haloSpecs.notNil) {
 				synthSpecs.putAll(haloSpecs);
 			};
-			^synthSpecs
+			^synthSpecs.parent_(Spec.specs)
 		};
 
 		// always look in halo first:

--- a/classes/SystemOverwrites/extNodeProxy.sc
+++ b/classes/SystemOverwrites/extNodeProxy.sc
@@ -23,6 +23,14 @@ or at least avoid also using addSpec for the same parameter name.
 */
 
 + NodeProxy {
+	// convenience:
+	// copy implicit specs up into halo for faster access
+	addImplicitSpecsToHalo {
+		this.specs.keysValuesDo { |key, value|
+			this.addSpec(key, value)
+		}
+	}
+
 	getSpec { |key|
 
 		var foundSpec;

--- a/classes/SystemOverwrites/extNodeProxy.sc
+++ b/classes/SystemOverwrites/extNodeProxy.sc
@@ -1,41 +1,46 @@
-/* overwrite getSpec:
+/*
+why have NodeProxy:getSpec,
+and what is the preference order?
+
+NodeProxy has two ways to define a spec for a given parameter name:
+implicitly in the synth function(s), as in
+
+Ndef(\x, { Pulse.ar(\freqx.kr(200, spec: [3, 300, \exp])) });
+
+and the general JITLib way of using addSpec (Halo).
+Ndef(\x).addSpec(\freqx, [3, 300, \exp])
+
+As the specs for the same param name can be different in these two places,
+it it is necessary to decide which one to use:
 addSpec / Halo has priority over implicit specs;
-if nothing is found in Halo, look in proxy.specs.
+if nothing is found in Halo, then we look in proxy.specs.
 
-This precedence is useful for tuning specs while sound is running:
-once a good spec is found, one can place it in the synth func.
-If you always prefer to use implicit specs,
-just avoid using addSpec with the same parameter name.
+This precedence is useful for tuning specs while the sound continues:
+once a good spec is found, one can place it back in the synth func.
+If you always prefer to use implicit specs, just use implicit specs only,
+or at least avoid also using addSpec for the same parameter name.
 
-////// Test/Show using addSpec and implicit controls:
-
-// define an implicit spec in synthfunc:
-Ndef(\x, { Pulse.ar(\freqx.kr(200, spec: [3, 300, \exp])) * 0.1 });
-// it should be here:
-Ndef(\x).specs;
-// findFirstSpecFor should find it too
-Ndef(\x).findFirstSpecFor(\freqx);
-// and getSpec finds it
-Ndef(\x).getSpec(\freqx);
-
-// make sure we don't have one in the halo:
-Ndef(\x).addSpec(\freqx, nil);
-
-// use addSpec: the newly added explicit spec is used
-Ndef(\x).addSpec(\freqx, [5, 500, \exp]);
-Ndef(\x).getSpec(\freqx);
-
-// when we remove the explicit spec again ..
-Ndef(\x).addSpec(\freqx, nil);
-// we see the implicit one again.
-Ndef(\x).getSpec(\freqx);
 */
 
 + NodeProxy {
-	getSpec { |key, value|
+	getSpec { |key|
+
+		var foundSpec;
+
+		// if no key given, return a dict with all specs;
+		// combining synth specs and prioritized Halo specs.
+		if (key.isNil) {
+			var synthSpecs = this.specs;
+			var haloSpecs = super.getSpec;
+			// Halo specs will override synth specs.
+			if (haloSpecs.notNil) {
+				synthSpecs.putAll(haloSpecs);
+			};
+			^synthSpecs
+		};
 
 		// always look in halo first:
-		var foundSpec = super.getSpec(key, value);
+		foundSpec = super.getSpec(key);
 		if (foundSpec.notNil) { ^foundSpec };
 
 		// if nothing in Halo, check in synthfunc metadata:

--- a/classes/SystemOverwrites/extProxySupport.sc
+++ b/classes/SystemOverwrites/extProxySupport.sc
@@ -1,0 +1,55 @@
+/* non-gui functions related to (mainly Node)-Proxies and specs:
+
+// true:
+\wet1.isFilterRole  // true
+\mix5.isFilterRole  // true
+\wet.isFilterRole    //false
+\mix5berta.isFilterRole // false
+\wet2234d.isFilterRole  // false
+*/
+
++ Symbol {
+	// support for nodeproxy filter roles
+	isFilterRole {
+		var str, splitIndex, head, tail;
+		str = this.asString;
+		splitIndex = str.detectIndex(_.isDecDigit);
+		if (splitIndex.isNil) { ^false };
+
+		head = str.keep(splitIndex);
+		// roles could be looked up somewhere
+		if ([ "wet", "mix" ].any (_ == head).not) { ^false };
+
+		tail = str.drop(splitIndex);
+		^tail.every(_.isDecDigit);
+	}
+}
+
++ Spec {
+	// for guis, guess a reasonable spec range if none given
+	*guess { |key, value|
+
+		if (key.isFilterRole) { ^[0, 1].asSpec };
+
+		if (value.isKindOf(Array)) { value = value[0] };
+		if (value.isKindOf(SimpleNumber).not) { ^nil };
+
+		// label units as \guess so one can throw spec away later.
+		^if (value.abs > 0) {
+			ControlSpec(value/20, value*20, \exp, 0, value, \guess)
+		} {
+			ControlSpec(-2, 2, \lin, 0, value, \guess)
+		};
+	}
+}
+
++ TaskProxy {
+	// use \orderNames in halo for maintaining non-alphabetic order of names,
+	// ananlog to NodeProxy, where controlKeys have an order.
+	controlKeys {
+		var cKeys = this.getHalo(\orderedNames);
+		if (cKeys.notNil) { ^cKeys };
+		cKeys = if (envir.notNil) { envir.keys(Array).sort } { [] };
+		^cKeys;
+	}
+}


### PR DESCRIPTION
While addSpec/getSpec is implement in Object, so objects like TaskProxy, Tdef, 
PatternProxy, Pdef and similar objects with get/set-able parameters 
can keep their own specs, NodeProxy needs its own getSpec method, 
because a NodeProxy may have implicit specs embedded in its objects' metadata. 

In this PR, explicit proxy.addSpec has priority over implicit specs;
if nothing is found in Halo, it will look in proxy.specs.

This precedence is useful for tuning specs while the sound is running:
once a final good spec is found, one can place it back in the synth func.
The only caveat: People who always prefer to use implicit specs,
need to avoid using addSpec with the same parameter name 
to avoid confusion. 

This PR resolves #22.

Explain and test-show how to use addSpec and implicit controls:
```
// define an implicit spec in synthfunc:
Ndef(\x, { Pulse.ar(\freqx.kr(200, spec: [3, 300, \exp])) * 0.1 });
// it should be here:
Ndef(\x).specs;
// findFirstSpecFor should find it too
Ndef(\x).findFirstSpecFor(\freqx);
// and getSpec should also find it:
Ndef(\x).getSpec(\freqx);

// make sure we don't have a spec in the halo:
Ndef(\x).addSpec(\freqx, nil);

// now use addSpec: the newly added explicit spec is used
Ndef(\x).addSpec(\freqx, [5, 500, \exp]);
Ndef(\x).getSpec(\freqx);

// tune the spec until you like it ...
// when done, bring it back into the synth func
Ndef(\x, { Pulse.ar(\freqx.kr(200, spec: [6, 666, \exp])) * 0.1 });

// and now, when we remove the explicit spec ..
Ndef(\x).addSpec(\freqx, nil);
// we see the implicit one gets used. 
Ndef(\x).getSpec(\freqx);
```